### PR TITLE
chore: remove syntax-check[specific] on warn_list

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,3 @@
 ---
 warn_list:
   - experimental
-  - syntax-check[specific]


### PR DESCRIPTION
## Description
remove ansible-lint 6.15.0 warning on syntax-check

## Motivation and Context
chore

## How Has This Been Tested?
locally and pipeline

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed including pre-commit and github actions.
