### PR TITLE
ci(dependabot): set schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
## Description
Lower dependabot update check schedule to monthly

## Motivation and Context
Too many PR.
It does not seem there is a difference between critical/security updates and normal ones per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

## How Has This Been Tested?
Github CI dependabot only apply to main. no devel branch test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed including pre-commit and github actions.
- [ ] Used in production.