### PR TITLE
ci(default): remove ubuntu:16.04

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      interval: "monthly"

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -70,6 +70,9 @@ jobs:
         continue-on-error: true
       - name: Environment
         run: |
+          set -x
+          ansible --version
+          ansible-config dump --only-changed -t all
           pwd
           env
           find -ls

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -36,8 +36,6 @@ jobs:
             experimental: false
           - molecule_distro: 'ubuntu:18.04'
             experimental: false
-          - molecule_distro: 'ubuntu:16.04'
-            experimental: false
           - molecule_distro: 'debian:10'
             experimental: false
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,7 +76,6 @@ jobs:
         uses: trufflesecurity/trufflehog@e856a6890d0da5a218f4f9283500b80043884641
         with:
           path: ${{ env.ANSIBLE_ROLE }}
-          base: ${{ github.event.repository.default_branch }}
           head: HEAD
           extra_args: --debug --only-verified
         if: ${{ always() }}


### PR DESCRIPTION
## Description
* remove ubuntu:16.04 from default ci as python 3.5 not supported anymore with ansible
* catch-up devel with minor ci changes

## Motivation and Context
* clean unsupported/old system
* maintain easy merge

## How Has This Been Tested?
github ci

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed including pre-commit and github actions.
- [ ] Used in production.