### PR TITLE
fix(meta): remove standalone as breaks galaxy_importer

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,6 @@ galaxy_info:
   description: Add unix user with optional authorized keys and sudo
   license: BSD
   min_ansible_version: '1.9'
-  standalone: true
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
## Description
remove standalone as breaks galaxy_importer

## Motivation and Context
Try fixing galaxy role release
https://github.com/juju4/ansible-adduser/actions/runs/11990259755

and
`galaxy_importer.exceptions.LegacyRoleSchemaError: unknown field in galaxy_info: LegacyGalaxyInfo.__init__() got an unexpected keyword argument 'standalone'`

## How Has This Been Tested?
To be test after in main and `ansible-galaxy role import --branch main juju4 ansible-adduser`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed including pre-commit and github actions.
- [ ] Used in production.