### PR TITLE
fix(debian): sudo group is sudo, not adm

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,7 +92,7 @@
   block:
     - name: Debian | set groups
       ansible.builtin.set_fact:
-        final_groups: "{{ adduser_groups + ['adm'] }}"
+        final_groups: "{{ adduser_groups + ['sudo'] }}"
       when: ansible_os_family == "Debian"
     - name: RedHat | set groups
       ansible.builtin.set_fact:


### PR DESCRIPTION
## Description
debian normal sudo group is sudo. Reviewed on Debian-12 and Ubuntu-24.04

## Motivation and Context
bug, else it does not work as expected

## How Has This Been Tested?
ci

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed including pre-commit and github actions.
- [x] Used in production.